### PR TITLE
fixed job roles layout

### DIFF
--- a/public/stylesheets/homepage.css
+++ b/public/stylesheets/homepage.css
@@ -207,8 +207,9 @@
 }
 
 #homepage #job-posting .job-header .job {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 4fr 1fr;
+  justify-items: center;
   align-items: center;
   border: 0.5px solid rgba(17, 20, 76, 0.25);
   border-radius: 5px;
@@ -218,6 +219,7 @@
 }
 
 #homepage #job-posting .job-header .job li {
+  width: 100%;
   line-height: 16px;
   display: inline-block;
 }
@@ -237,8 +239,10 @@
 #homepage #job-posting .job-header .job li p {
   font-weight: 600;
   font-size: 18px;
-  margin-bottom: 0;
   color: #11144c;
+  text-align: left;
+  width: 90%;
+  margin: 0 auto;
 }
 
 #homepage #job-posting .job-header .job li img {


### PR DESCRIPTION
Ensure that the components in the job roles section was perfectly set in its own space so the size of one does not affect the other, aligned the jobs description section to the left.